### PR TITLE
karin-common: use specific idProduct for usb paths

### DIFF
--- a/aosp_sgp771_common.mk
+++ b/aosp_sgp771_common.mk
@@ -56,4 +56,4 @@ PRODUCT_CHARACTERISTICS := tablet
 
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.sf.lcd_density=320 \
-    ro.usb.pid_suffix=1BA
+    ro.usb.pid_suffix=1CF


### PR DESCRIPTION
from 28.0.A.7.24

Signed-off-by: David Viteri davidteri91@gmail.com
