### PR TITLE
karin: cleanup audio_policy

### DIFF
--- a/rootdir/system/etc/audio_policy.conf
+++ b/rootdir/system/etc/audio_policy.conf
@@ -63,20 +63,6 @@ audio_hw_modules {
         devices AUDIO_DEVICE_OUT_SPEAKER|AUDIO_DEVICE_OUT_EARPIECE|AUDIO_DEVICE_OUT_WIRED_HEADSET|AUDIO_DEVICE_OUT_WIRED_HEADPHONE|AUDIO_DEVICE_OUT_ALL_SCO
         flags AUDIO_OUTPUT_FLAG_DIRECT|AUDIO_OUTPUT_FLAG_VOIP_RX
       }
-      high_res_audio {
-        sampling_rates 96000
-        channel_masks AUDIO_CHANNEL_OUT_STEREO
-        formats AUDIO_FORMAT_PCM_8_24_BIT
-        devices AUDIO_DEVICE_OUT_WIRED_HEADSET|AUDIO_DEVICE_OUT_WIRED_HEADPHONE
-        flags AUDIO_OUTPUT_FLAG_DIRECT|AUDIO_OUTPUT_FLAG_HIGH_RES_AUDIO
-      }
-      dsee_direct {
-        sampling_rates 96000
-        channel_masks AUDIO_CHANNEL_OUT_STEREO
-        formats AUDIO_FORMAT_PCM_8_24_BIT
-        devices AUDIO_DEVICE_OUT_WIRED_HEADSET|AUDIO_DEVICE_OUT_WIRED_HEADPHONE
-        flags AUDIO_OUTPUT_FLAG_DIRECT|AUDIO_OUTPUT_FLAG_DSEE|AUDIO_OUTPUT_FLAG_HIGH_RES_AUDIO
-      }
     }
     inputs {
       primary {
@@ -102,6 +88,14 @@ audio_hw_modules {
         devices AUDIO_DEVICE_OUT_ALL_A2DP
       }
     }
+    inputs {
+      a2dp {
+        sampling_rates 44100|48000
+        channel_masks AUDIO_CHANNEL_IN_MONO|AUDIO_CHANNEL_IN_STEREO
+        formats AUDIO_FORMAT_PCM_16_BIT
+        devices AUDIO_DEVICE_IN_BLUETOOTH_A2DP
+      }
+    }
   }
   usb {
     outputs {
@@ -121,8 +115,8 @@ audio_hw_modules {
     inputs {
       usb_device {
         sampling_rates dynamic
-        channel_masks AUDIO_CHANNEL_IN_STEREO
-        formats AUDIO_FORMAT_PCM_16_BIT
+        channel_masks dynamic
+        formats dynamic
         devices AUDIO_DEVICE_IN_USB_DEVICE
       }
     }


### PR DESCRIPTION
remove high_res_audio parameter which is sony equalizer conf
remove dsee_direct parameter which is sony equalizer conf

also add inputs for bluetooth and update inputs usb_device as other kitakami targets

Signed-off-by: David Viteri davidteri91@gmail.com
