### PR TITLE
karin: drop TARGET_TAP_TO_WAKE_STRING

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -17,4 +17,3 @@ include device/sony/kitakami/BoardConfig.mk
 TARGET_BOOTLOADER_BOARD_NAME := SGP771
 
 TARGET_TAP_TO_WAKE_NODE := "/sys/devices/virtual/input/maxim_sti/gesture_wakeup"
-TARGET_TAP_TO_WAKE_STRING := true


### PR DESCRIPTION
it was used on shinano due to sirius path isn't using 1 : 0 for tap to wake feature... here this is not needed

Signed-off-by: David Viteri davidteri91@gmail.com
