### PR TITLE
karin: Move kernel defconf to common (karin_wind)

### DIFF
--- a/aosp_sgp771.mk
+++ b/aosp_sgp771.mk
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TARGET_KERNEL_CONFIG := aosp_kitakami_karin_defconfig
-
 PRODUCT_COPY_FILES := \
 
 # Device Init


### PR DESCRIPTION
Karin [windy] kernel defconf was unified
https://github.com/sonyxperiadev/kernel/commit/53ffd38ba9381fac5e5777ab09453b52d0785164

Change-Id: I639b57a112087c5457ff1c5dbfd8bbf166aecf94
